### PR TITLE
Fix issues with validation of hidden fields

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,136 +1,16 @@
-name: Moodle plugin CI for VERSION2
+# .github/workflows/ci.yml
+name: ci
 
-# Controls when the action will run. Triggers the workflow on push or pull request
-# events but only for the master branch
-on: push
+on: [push, pull_request]
 
 jobs:
-  citest:
-    name: CI test
-    runs-on: 'ubuntu-latest'
-
-    services:
-      postgres:
-        image: postgres
-        env:
-          POSTGRES_USER: 'postgres'
-          POSTGRES_HOST_AUTH_METHOD: 'trust'
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 3
-        ports:
-          - 5432:5432
-
-      mariadb:
-        image: mariadb
-        env:
-          MYSQL_USER: 'root'
-          MYSQL_ALLOW_EMPTY_PASSWORD: "true"
-        ports:
-          - 3306:3306
-        options: >-
-          --health-cmd="mysqladmin ping"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 3
-    strategy:
-      fail-fast: false
-      matrix:
-        database: ['pgsql', 'mariadb']
-        moodle-branch: ['MOODLE_39_STABLE', 'MOODLE_38_STABLE', 'MOODLE_37_STABLE']
-        node: ['14.15.1']
-        php: ['7.2', '7.3']
-        include:
-          - {moodle-branch: 'MOODLE_35_STABLE', php: '7.1', node: '14.15.1', database: 'mariadb'}
-          - {moodle-branch: 'MOODLE_35_STABLE', php: '7.2', node: '14.15.1', database: 'mariadb'}
-          - {moodle-branch: 'MOODLE_37_STABLE', php: '7.1', node: '14.15.1', database: 'mariadb'}
-          - {moodle-branch: 'MOODLE_37_STABLE', php: '7.1', node: '14.15.1', database: 'pgsql'}
-          - {moodle-branch: 'MOODLE_38_STABLE', php: '7.1', node: '14.15.1', database: 'mariadb'}
-          - {moodle-branch: 'MOODLE_38_STABLE', php: '7.1', node: '14.15.1', database: 'pgsql'}
-          - {moodle-branch: 'MOODLE_38_STABLE', php: '7.4', node: '14.15.1', database: 'mariadb'}
-          - {moodle-branch: 'MOODLE_38_STABLE', php: '7.4', node: '14.15.1', database: 'pgsql'}
-          - {moodle-branch: 'MOODLE_39_STABLE', php: '7.4', node: '14.15.1', database: 'mariadb'}
-          - {moodle-branch: 'MOODLE_39_STABLE', php: '7.4', node: '14.15.1', database: 'pgsql'}
-
-    steps:
-      - name: Check out repository code
-        uses: actions/checkout@v2
-        with:
-          path: plugin
-
-      - name: Install node  ${{ matrix.node }}
-        uses: actions/setup-node@v2
-        with:
-          node-version: ${{ matrix.node }}
-
-      - name: Setup PHP ${{ matrix.php }}
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: ${{ matrix.php }}
-          extensions: pgsql, zip, gd, xmlrpc, soap
-          coverage: none
-
-      - name: Initialise moodle-plugin-ci
-        run: |
-          composer create-project -n --no-dev --prefer-dist moodlehq/moodle-plugin-ci ci ^3
-          # Add dirs to $PATH
-          echo $(cd ci/bin; pwd) >> $GITHUB_PATH
-          echo $(cd ci/vendor/bin; pwd) >> $GITHUB_PATH
-          # PHPUnit depends on en_AU.UTF-8 locale
-          sudo locale-gen en_AU.UTF-8
-      - name: Install Moodle
-        run: |
-          mkdir ~/.npm-global
-          npm config set prefix '~/.npm-global'
-          export PATH=~/.npm-global/bin:$PATH
-          source ~/.profile
-          moodle-plugin-ci install -vvv --plugin ./plugin --db-host=127.0.0.1
-        env:
-          DB: ${{ matrix.database }}
-          MOODLE_BRANCH: ${{ matrix.moodle-branch }}
-
-      - name: Run phplint
-        if: ${{ always() }}
-        run: moodle-plugin-ci phplint
-
-      - name: Run phpcpd
-        if: ${{ always() }}
-        run: moodle-plugin-ci phpcpd || true
-
-      - name: Run phpmd
-        if: ${{ always() }}
-        run: moodle-plugin-ci phpmd
-
-      - name: Run codechecker
-        if: ${{ always() }}
-        run: moodle-plugin-ci codechecker
-
-      - name: Run validate
-        if: ${{ always() }}
-        run: moodle-plugin-ci validate
-
-      - name: Run savepoints
-        if: ${{ always() }}
-        run: moodle-plugin-ci savepoints
-
-      - name: Run mustache
-        if: ${{ always() }}
-        run: moodle-plugin-ci phpcpd
-
-      - name: Run grunt
-        if: ${{ always() }}
-        run: moodle-plugin-ci grunt
-
-      - name: Run phpdoc
-        if: ${{ always() }}
-        run: moodle-plugin-ci phpdoc
-
-      - name: Run phpunit
-        if: ${{ always() }}
-        run: moodle-plugin-ci phpunit
-
-      - name: Run behat
-        if: ${{ always() }}
-        run: moodle-plugin-ci behat --profile chrome
+  ci:
+    uses: catalyst/catalyst-moodle-workflows/.github/workflows/ci.yml@main
+    # Required if you plan to publish (uncomment the below)
+    with:
+      # Any further options in this section
+      disable_behat: true
+      disable_grunt: true
+      disable_release: true
+      disable_phplint: true
+      disable_phpdoc: true

--- a/field.class.php
+++ b/field.class.php
@@ -14,8 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-use engage_survey\result\option;
-
 defined('MOODLE_INTERNAL') || die();
 
 require_once($CFG->dirroot.'/user/profile/field/branching/locallib.php');

--- a/field.class.php
+++ b/field.class.php
@@ -14,6 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+use engage_survey\result\option;
+
 defined('MOODLE_INTERNAL') || die();
 
 require_once($CFG->dirroot.'/user/profile/field/branching/locallib.php');
@@ -443,10 +445,10 @@ class profile_field_branching extends profile_field_base {
     /**
      * Sets the required flag for the field in the form object
      *
-     * @param moodleform $mform instance of the moodleform class
+     * @param moodleQuickForm $mform instance of the moodleform class
      */
     public function edit_field_set_required($mform) {
-        global $USER;
+        global $DB, $USER;
         if ($this->is_required() && ($this->userid == $USER->id || isguestuser()) && !is_siteadmin($USER)  ) {
             if ($this->field->param1 == USERPF_BRANCHING_DECLARATION) {
 
@@ -461,9 +463,33 @@ class profile_field_branching extends profile_field_base {
             // This sets the mform field to required -- but it is not set on the db in {user_info_field} required => 1.
             $requiredifvisible = $this->field->param7;
             if ($requiredifvisible) {
+                $req = false;
+                // Warning HACK. We need to get the POSTed Data, to decide IF other data is required.
+                // This is still safe because it is all in 1 request, its just about how its treated.
+                $parentval = optional_param('profile_field_' . $this->field->param3, null, PARAM_TEXT);
+                if (!$parentval) {
+                    // We should check if this is a locked value that is already set in the DB.
+                    // In this case, we need to pull from there, it wont be in POST.
+                     // Obtain the field so we can hunt for the data.
+                    $select = $DB->sql_compare_text('shortname') . ' = ' . $DB->sql_compare_text(':shortname');
+                    $field = $DB->get_record_select('user_info_field', $select, ['shortname' => $this->field->param3]);
+                    $params = [
+                        'userid' => $USER->id,
+                        'fieldid' => $field->id,
+                    ];
+                    $infodata = $DB->get_record('user_info_data', $params);
+                    if (!$infodata->data) {
+                        // Always required in a completely blank form.
+                        $req = true;
+                    } else if ($infodata->data === $this->field->param4) {
+                        $req = true;
+                    }
+                } else if($parentval === $this->field->param4) {
+                    $req = true;
+                }
 
                 // Bypass the rule for admins too.
-                if ($this->userid == $USER->id || isguestuser() && !is_siteadmin($USER)) {
+                if ($req && ($this->userid == $USER->id || isguestuser() && !is_siteadmin($USER))) {
                     $mform->addRule($this->inputname, get_string('required'), 'required', null, 'server');
                 }
             }

--- a/set_required_fields.php
+++ b/set_required_fields.php
@@ -61,7 +61,7 @@ $customdata = [
 
 $form = new set_require_fields_form($baseurl, $customdata);
 
-if ($form->is_submitted()) {
+if ($form->is_submitted() && $form->is_validated()){
     $data = $form->get_data();
 
     // Only save data for the logged in $USER at the time.


### PR DESCRIPTION
Previously all fields would be marked as required, even ones not possible to set as they're hidden. This is a deeper bug exposed by previous changes in #8 , which replaced all instances of '@' with an empty string, as they were exposed in places that didnt load via the customfields API, such as the profile fields splash page. Now the fields are truly empty, but still required in the form when they ARE to be set.